### PR TITLE
feat: add explorer ranks based on xp

### DIFF
--- a/app/src/main/java/com/pv239/beelocal/ui/screens/profile/components/ExplorerRank.kt
+++ b/app/src/main/java/com/pv239/beelocal/ui/screens/profile/components/ExplorerRank.kt
@@ -1,0 +1,53 @@
+package com.pv239.beelocal.ui.screens.profile.components
+
+import androidx.annotation.StringRes
+import androidx.compose.ui.graphics.Color
+import com.pv239.beelocal.R
+
+/**
+ * 8-tier XP ladder used to brand a user's profile with a flavour title and
+ * matching colour. Tiers are ordered from the entry-level [Larva] to the
+ * end-game [MasterExplorer]; each tier carries the **minimum XP** required
+ * to reach it. Use [rankForXp] to resolve the rank for a given XP value and
+ * [nextRank] to drive any progression UI.
+ *
+ * Colours were picked to feel cohesive with the BeeLocal bee/honey palette:
+ * the early tiers stay desaturated, the mid-game leans into honey/orange,
+ * and the late game shifts towards regal purples and a celebratory gold.
+ */
+enum class ExplorerRank(
+    @StringRes val labelRes: Int,
+    val minXp: Int,
+    val color: Color,
+) {
+    Larva(R.string.profile_rank_larva, minXp = 0, color = Color(0xFF9E9E9E)),
+    Hatchling(R.string.profile_rank_hatchling, minXp = 50, color = Color(0xFFB08968)),
+    WorkerBee(R.string.profile_rank_worker_bee, minXp = 150, color = Color(0xFFE0A800)),
+    Forager(R.string.profile_rank_forager, minXp = 500, color = Color(0xFFE07A1F)),
+    Scout(R.string.profile_rank_scout, minXp = 1_000, color = Color(0xFF2E8B57)),
+    Pathfinder(R.string.profile_rank_pathfinder, minXp = 2_500, color = Color(0xFF1E88E5)),
+    HiveMaster(R.string.profile_rank_hive_master, minXp = 5_000, color = Color(0xFF7B3FF2)),
+    MasterExplorer(R.string.profile_rank_master_explorer, minXp = 10_000, color = Color(0xFFFFB300)),
+}
+
+/**
+ * Resolves the highest rank whose [ExplorerRank.minXp] threshold has been
+ * met by [xp]. A negative XP value is clamped to [ExplorerRank.Larva].
+ */
+fun rankForXp(xp: Int): ExplorerRank {
+    // Iterate descending so the first match is automatically the highest
+    // tier the user qualifies for. This keeps the code resilient if more
+    // ranks are inserted later.
+    val ordered = ExplorerRank.entries.sortedByDescending { it.minXp }
+    return ordered.firstOrNull { xp >= it.minXp } ?: ExplorerRank.Larva
+}
+
+/**
+ * Returns the next rank above [rank], or `null` if [rank] is already the
+ * top tier. Handy for "X XP to next rank" hints.
+ */
+fun nextRank(rank: ExplorerRank): ExplorerRank? {
+    val ordered = ExplorerRank.entries.sortedBy { it.minXp }
+    val idx = ordered.indexOf(rank)
+    return ordered.getOrNull(idx + 1)
+}

--- a/app/src/main/java/com/pv239/beelocal/ui/screens/profile/components/ExplorerRanksDialog.kt
+++ b/app/src/main/java/com/pv239/beelocal/ui/screens/profile/components/ExplorerRanksDialog.kt
@@ -1,0 +1,305 @@
+package com.pv239.beelocal.ui.screens.profile.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.pv239.beelocal.R
+
+/**
+ * Modal that explains the 8-tier XP ladder.
+ *
+ * Layout:
+ *  - Header progress block showing the current rank, XP toward the next
+ *    rank, and a linear progress bar tinted in the next rank's colour.
+ *  - Scrollable list of every rank with its coloured swatch, name, and XP
+ *    threshold. The user's current tier is outlined and tinted so the
+ *    dialog doubles as a "where am I" indicator even when scrolled.
+ *
+ * The list is intentionally height-constrained + scrollable so the dialog
+ * stays well-mannered on smaller phones — `AlertDialog`'s text slot would
+ * otherwise push past the screen bounds once new ranks are added.
+ */
+@Composable
+fun ExplorerRanksDialog(
+    currentXp: Int,
+    onDismiss: () -> Unit,
+) {
+    val currentRank = rankForXp(currentXp)
+    val upcoming = nextRank(currentRank)
+    // List in ascending order so the player sees their journey from larva
+    // upwards rather than from end-game down.
+    val ranks = ExplorerRank.entries.sortedBy { it.minXp }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                text = stringResource(R.string.profile_ranks_dialog_title),
+                fontWeight = FontWeight.Black,
+            )
+        },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(
+                    text = stringResource(R.string.profile_ranks_dialog_subtitle),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+
+                ProgressHeader(
+                    currentXp = currentXp,
+                    currentRank = currentRank,
+                    nextRank = upcoming,
+                )
+
+                Spacer(modifier = Modifier.height(4.dp))
+
+                // Constrain the list height so the dialog never overflows
+                // on small screens. heightIn(max = ...) lets it shrink to
+                // fit short lists (e.g. when fewer ranks are added later).
+                val scrollState = rememberScrollState()
+                Column(
+                    modifier = Modifier
+                        .heightIn(max = 320.dp)
+                        .verticalScroll(scrollState),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    ranks.forEach { rank ->
+                        RankRow(
+                            rank = rank,
+                            isCurrent = rank == currentRank,
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(
+                    text = stringResource(R.string.profile_ranks_dialog_close),
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+        },
+        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        tonalElevation = 4.dp,
+    )
+}
+
+/**
+ * Compact progress card sitting above the rank list. Shows "Current rank
+ * → Next rank", the XP delta to the next rank, and a linear progress bar
+ * tinted in the next rank's colour. When the user is already at the top
+ * tier the bar fills and a max-rank caption is shown instead of XP-to-go.
+ */
+@Composable
+private fun ProgressHeader(
+    currentXp: Int,
+    currentRank: ExplorerRank,
+    nextRank: ExplorerRank?,
+) {
+    // Compute progress within the [currentRank.minXp, nextRank.minXp]
+    // window. If we're already at the top we just fill the bar.
+    val progress: Float
+    val xpRemaining: Int
+    if (nextRank != null) {
+        val span = (nextRank.minXp - currentRank.minXp).coerceAtLeast(1)
+        val within = (currentXp - currentRank.minXp).coerceAtLeast(0)
+        progress = (within.toFloat() / span.toFloat()).coerceIn(0f, 1f)
+        xpRemaining = (nextRank.minXp - currentXp).coerceAtLeast(0)
+    } else {
+        progress = 1f
+        xpRemaining = 0
+    }
+
+    // When at the max rank we tint the bar in the current rank's colour
+    // (no "next" to point to). Otherwise use the next rank's colour as a
+    // visual carrot that hints at what the user is climbing toward.
+    val accent = nextRank?.color ?: currentRank.color
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                RankBadge(rank = currentRank)
+                if (nextRank != null) {
+                    Text(
+                        text = "→",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    RankBadge(rank = nextRank, faded = true)
+                } else {
+                    Text(
+                        text = stringResource(R.string.profile_ranks_dialog_max_rank),
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Black,
+                        color = currentRank.color,
+                    )
+                }
+            }
+
+            LinearProgressIndicator(
+                progress = { progress },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(8.dp)
+                    .clip(RoundedCornerShape(50)),
+                color = accent,
+                trackColor = accent.copy(alpha = 0.18f),
+            )
+
+            val captionText = if (nextRank != null) {
+                stringResource(
+                    R.string.profile_ranks_dialog_progress_caption,
+                    currentXp,
+                    nextRank.minXp,
+                    xpRemaining,
+                )
+            } else {
+                stringResource(
+                    R.string.profile_ranks_dialog_progress_caption_max,
+                    currentXp,
+                )
+            }
+            Text(
+                text = captionText,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun RankBadge(rank: ExplorerRank, faded: Boolean = false) {
+    val tint = if (faded) rank.color.copy(alpha = 0.75f) else rank.color
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(14.dp)
+                .clip(CircleShape)
+                .background(tint),
+        )
+        Text(
+            text = stringResource(rank.labelRes),
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Bold,
+            color = tint,
+        )
+    }
+}
+
+@Composable
+private fun RankRow(
+    rank: ExplorerRank,
+    isCurrent: Boolean,
+) {
+    // Highlight the current rank with a tinted background and a thin outline
+    // in the rank's own colour so it pops without overwhelming the list.
+    val containerColor = if (isCurrent) {
+        rank.color.copy(alpha = 0.12f)
+    } else {
+        MaterialTheme.colorScheme.surfaceContainerLow
+    }
+
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .then(
+                if (isCurrent) {
+                    Modifier.border(
+                        width = 1.5.dp,
+                        color = rank.color,
+                        shape = RoundedCornerShape(14.dp),
+                    )
+                } else {
+                    Modifier.border(
+                        width = 1.dp,
+                        color = Color.Transparent,
+                        shape = RoundedCornerShape(14.dp),
+                    )
+                }
+            ),
+        shape = RoundedCornerShape(14.dp),
+        color = containerColor,
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(28.dp)
+                    .clip(CircleShape)
+                    .background(rank.color),
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(rank.labelRes),
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = rank.color,
+                )
+                Text(
+                    text = stringResource(
+                        R.string.profile_ranks_dialog_threshold,
+                        rank.minXp,
+                    ),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (isCurrent) {
+                Text(
+                    text = stringResource(R.string.profile_ranks_dialog_you),
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.Black,
+                    color = rank.color,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/pv239/beelocal/ui/screens/profile/components/ExplorerRanksDialog.kt
+++ b/app/src/main/java/com/pv239/beelocal/ui/screens/profile/components/ExplorerRanksDialog.kt
@@ -51,6 +51,13 @@ import com.pv239.beelocal.R
 fun ExplorerRanksDialog(
     currentXp: Int,
     onDismiss: () -> Unit,
+    /**
+     * When `true`, the "YOU" chip is rendered next to the active tier. Only
+     * the profile owner should see it; when browsing another user's profile
+     * the dialog should describe the ladder without claiming any tier as
+     * belonging to the viewer.
+     */
+    showYouMarker: Boolean = true,
 ) {
     val currentRank = rankForXp(currentXp)
     val upcoming = nextRank(currentRank)
@@ -93,9 +100,11 @@ fun ExplorerRanksDialog(
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     ranks.forEach { rank ->
+                        val isCurrent = rank == currentRank
                         RankRow(
                             rank = rank,
-                            isCurrent = rank == currentRank,
+                            isCurrent = isCurrent,
+                            isCurrentAndSelf = isCurrent && showYouMarker,
                         )
                     }
                 }
@@ -235,6 +244,7 @@ private fun RankBadge(rank: ExplorerRank, faded: Boolean = false) {
 private fun RankRow(
     rank: ExplorerRank,
     isCurrent: Boolean,
+    isCurrentAndSelf: Boolean = isCurrent,
 ) {
     // Highlight the current rank with a tinted background and a thin outline
     // in the rank's own colour so it pops without overwhelming the list.
@@ -292,7 +302,7 @@ private fun RankRow(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
-            if (isCurrent) {
+            if (isCurrentAndSelf) {
                 Text(
                     text = stringResource(R.string.profile_ranks_dialog_you),
                     style = MaterialTheme.typography.labelSmall,

--- a/app/src/main/java/com/pv239/beelocal/ui/screens/profile/components/ProfileHero.kt
+++ b/app/src/main/java/com/pv239/beelocal/ui/screens/profile/components/ProfileHero.kt
@@ -17,6 +17,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -140,21 +144,38 @@ fun ProfileHero(
                 color = MaterialTheme.colorScheme.onBackground,
             )
 
+            // Current XP-based rank. Tapping the chip opens the
+            // ExplorerRanksDialog so the user can see how the ladder is
+            // structured and what the next step looks like.
+            val rank = rankForXp(xp)
+            var showRanksDialog by remember { mutableStateOf(false) }
+
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(6.dp),
+                modifier = Modifier
+                    .clip(CircleShape)
+                    .clickable { showRanksDialog = true }
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
             ) {
                 Icon(
                     painter = painterResource(id = R.drawable.baseline_star_24),
                     contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
+                    tint = rank.color,
                     modifier = Modifier.size(18.dp),
                 )
                 Text(
-                    text = stringResource(R.string.profile_tagline_master_explorer),
+                    text = stringResource(rank.labelRes),
                     style = MaterialTheme.typography.labelLarge,
                     fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.tertiary,
+                    color = rank.color,
+                )
+            }
+
+            if (showRanksDialog) {
+                ExplorerRanksDialog(
+                    currentXp = xp,
+                    onDismiss = { showRanksDialog = false },
                 )
             }
         }

--- a/app/src/main/java/com/pv239/beelocal/ui/screens/profile/components/ProfileHero.kt
+++ b/app/src/main/java/com/pv239/beelocal/ui/screens/profile/components/ProfileHero.kt
@@ -27,6 +27,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.pv239.beelocal.R
@@ -57,6 +61,12 @@ fun ProfileHero(
      * user-profile screen where another user's avatar must not be editable.
      */
     editable: Boolean = true,
+    /**
+     * When `true`, the "YOU" marker inside the ExplorerRanksDialog is shown
+     * next to the active tier. Only the profile owner should see it — when
+     * viewing another user's profile the dialog purely describes the ladder.
+     */
+    isSelf: Boolean = true,
 ) {
 
     Column(
@@ -150,12 +160,22 @@ fun ProfileHero(
             val rank = rankForXp(xp)
             var showRanksDialog by remember { mutableStateOf(false) }
 
+            val ranksChipDescription = stringResource(
+                R.string.profile_ranks_chip_content_description
+            )
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(6.dp),
                 modifier = Modifier
                     .clip(CircleShape)
-                    .clickable { showRanksDialog = true }
+                    .clickable(
+                        role = Role.Button,
+                        onClick = { showRanksDialog = true },
+                    )
+                    .semantics {
+                        role = Role.Button
+                        contentDescription = ranksChipDescription
+                    }
                     .padding(horizontal = 8.dp, vertical = 4.dp),
             ) {
                 Icon(
@@ -175,6 +195,7 @@ fun ProfileHero(
             if (showRanksDialog) {
                 ExplorerRanksDialog(
                     currentXp = xp,
+                    showYouMarker = isSelf,
                     onDismiss = { showRanksDialog = false },
                 )
             }

--- a/app/src/main/java/com/pv239/beelocal/ui/screens/userprofile/UserProfileScreen.kt
+++ b/app/src/main/java/com/pv239/beelocal/ui/screens/userprofile/UserProfileScreen.kt
@@ -195,6 +195,7 @@ private fun UserProfileContent(
                 onAvatarClick = {}, // public view — no edit affordance
                 pictureUploading = false,
                 editable = false,
+                isSelf = state.isSelf,
             )
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -250,6 +250,26 @@
     <string name="profile_badge_public">PUBLIC</string>
     <string name="profile_badge_private">PRIVATE</string>
     <string name="profile_tagline_master_explorer">Master Explorer</string>
+    <!-- ── Explorer ranks (XP ladder) ───────────────────────────────────── -->
+    <string name="profile_rank_larva">Larva</string>
+    <string name="profile_rank_hatchling">Hatchling</string>
+    <string name="profile_rank_worker_bee">Worker Bee</string>
+    <string name="profile_rank_forager">Forager</string>
+    <string name="profile_rank_scout">Scout</string>
+    <string name="profile_rank_pathfinder">Pathfinder</string>
+    <string name="profile_rank_hive_master">Hive Master</string>
+    <string name="profile_rank_master_explorer">Master Explorer</string>
+    <string name="profile_ranks_dialog_title">Explorer Ranks</string>
+    <string name="profile_ranks_dialog_subtitle">Earn XP by completing challenges, routes, and weekly bingos to climb the hive.</string>
+    <!-- %1$d = minimum XP threshold for the rank -->
+    <string name="profile_ranks_dialog_threshold">%1$d XP 🍯</string>
+    <string name="profile_ranks_dialog_you">YOU</string>
+    <string name="profile_ranks_dialog_close">Got it</string>
+    <!-- %1$d = current XP, %2$d = next rank XP, %3$d = XP remaining to next rank -->
+    <string name="profile_ranks_dialog_progress_caption">%1$d / %2$d XP — %3$d to next rank 🍯</string>
+    <!-- %1$d = current XP -->
+    <string name="profile_ranks_dialog_progress_caption_max">%1$d XP — top of the hive! 👑</string>
+    <string name="profile_ranks_dialog_max_rank">MAX RANK</string>
     <string name="profile_change_picture">Change profile picture</string>
     <string name="profile_preferences_title">Preferences</string>
     <string name="profile_credentials_title">Credentials</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -270,6 +270,7 @@
     <!-- %1$d = current XP -->
     <string name="profile_ranks_dialog_progress_caption_max">%1$d XP — top of the hive! 👑</string>
     <string name="profile_ranks_dialog_max_rank">MAX RANK</string>
+    <string name="profile_ranks_chip_content_description">View ranks</string>
     <string name="profile_change_picture">Change profile picture</string>
     <string name="profile_preferences_title">Preferences</string>
     <string name="profile_credentials_title">Credentials</string>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an 8-tier explorer ranking system based on XP.
  * Added a tappable rank badge in profiles showing current tier and opening a ranks dialog.
  * Explorer Ranks dialog shows all tiers, color-coded swatches, XP thresholds, progress toward next rank, and a max-rank state.
  * “YOU” marker shown on the current user’s rank when viewing own profile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->